### PR TITLE
Allow appendTo to be iterated on

### DIFF
--- a/src/nodelist/js/nodelist.js
+++ b/src/nodelist/js/nodelist.js
@@ -14,7 +14,7 @@ function NWTNodeList(nodes) {
 	this.nodes = wrappedNodes;
 
 	var iteratedFunctions = [
-		'anim', 'remove', 'addClass', 'removeClass', 'setStyle', 'setStyles', 'removeStyle', 'removeStyles', 'swapClass', 'plug'
+		'anim', 'appendTo', 'remove', 'addClass', 'removeClass', 'setStyle', 'setStyles', 'removeStyle', 'removeStyles', 'swapClass', 'plug'
 	],
 
 	mythis = this;


### PR DESCRIPTION
I'm not sure if there's a better way to accomplish this, but this change allows `n.one.all.appendTo` so you can grab a bunch of nodes then move them.

This worked with my limited testing, but does anything break from this change?